### PR TITLE
(SERVER-2078) Update jenkins plugin to acquire default_plugins

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,7 +5,8 @@ mod 'stdlib',                :git => 'git://github.com/puppetlabs/puppetlabs-std
 mod 'inifile',               :git => 'git://github.com/puppetlabs/puppetlabs-inifile.git',                      :ref => '2.1.1'
 mod 'firewall',              :git => 'git://github.com/puppetlabs/puppetlabs-firewall.git',                     :ref => '1.7.1'
 mod 'java',                  :git => 'git://github.com/danielparks/puppetlabs-java.git',                        :ref => '1.3.0'
-mod 'jenkins',               :git => 'git://github.com/jenkinsci/puppet-jenkins.git',                           :ref => 'v1.7.0'
+# If jenkins does another tagged release at some point we should probably pick that up. Last one was 1.7.0 in Aug '16
+mod 'jenkins',               :git => 'git://github.com/jenkinsci/puppet-jenkins.git',                           :commit => '23df7764d58aed80b573621b102f82a702217a7a'
 mod 'archive',               :git => 'git://github.com/voxpupuli/puppet-archive.git',                           :ref => 'v2.2.0'
 mod 'python',                :git => 'git://github.com/stankevich/puppet-python.git',                           :ref => '1.18.2'
 mod 'rvm',                   :git => 'git://github.com/maestrodev/puppet-rvm',                                  :ref => 'v1.13.1'


### PR DESCRIPTION
The previous version of the jenkins module did not have the
default_plugins parameter that the new version of the
puppetserver_perf_driver module uses. To make sure we have that, this
commit updates the jenkins version to the same on in use in
puppetlabs-modules as of
https://github.com/puppetlabs/puppetlabs-modules/blob/0fa6080b2a573ea56a03fb42394837cc8c0182a1/Puppetfile